### PR TITLE
Upgrade Kotlin and add missing targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: jvm
+            os: ubuntu
+          - target: js
+            os: ubuntu
+          - target: wasmJs
+            os: ubuntu
+          - target: wasmWasi
+            os: ubuntu
+          - target: linuxX64
+            os: ubuntu
+          - target: macosArm64
+            os: macos
+          - target: mingwX64
+            os: windows
+          - target: iosSimulatorArm64
+            os: macos
+          - target: tvosSimulatorArm64
+            os: macos
+          - target: watchosSimulatorArm64
+            os: macos
+    runs-on: "${{ matrix.os }}-latest"
+    name: "test (${{ matrix.target }})"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-java@v4"
+        with:
+          distribution: "temurin"
+          java-version: 21
+      - run: "./gradlew core:${{ matrix.target }}Test"

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ hs_err_pid*
 
 # Build dirs
 build/
+.kotlin/
 
 # Gradle local stuff
 local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
     }
 }
 
@@ -16,11 +16,3 @@ allprojects {
         mavenCentral()
     }
 }
-
-
-
-
-// tasks.register("clean", Delete::class) {
-//     delete(rootProject.buildDir)
-// }
-

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,7 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+
 plugins {
     kotlin("multiplatform")
     kotlin("native.cocoapods")
@@ -22,18 +26,55 @@ tasks.dokkaHtml {
 
 
 kotlin {
-    iosX64()
-    iosArm64()
-    iosSimulatorArm64()
     jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "1.8"
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_1_8
         }
     }
+
     js(IR) {
-        //  useCommonJs()
         browser()
+        nodejs()
     }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        browser()
+        nodejs()
+        d8()
+    }
+
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmWasi {
+        nodejs()
+    }
+
+    // https://kotlinlang.org/docs/native-target-support.html#tier-1
+    macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+    iosArm64()
+
+    // https://kotlinlang.org/docs/native-target-support.html#tier-2
+    linuxX64()
+    linuxArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+
+    // https://kotlinlang.org/docs/native-target-support.html#tier-3
+    mingwX64()
+    watchosDeviceArm64()
+    androidNativeX64()
+    androidNativeArm32()
+    androidNativeArm64()
+
+    applyDefaultHierarchyTemplate()
 
     cocoapods {
         summary = "Kotlin version of Kxml"
@@ -43,48 +84,10 @@ kotlin {
             baseName = "ktxml"
         }
     }
-    
+
     sourceSets {
-        val commonMain by getting
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
-
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosSimulatorArm64Main by getting
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-            iosSimulatorArm64Main.dependsOn(this)
-        }
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosSimulatorArm64Test by getting
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
-            iosSimulatorArm64Test.dependsOn(this)
-        }
-
-        val jvmMain by getting
-        val jvmTest by getting {
-            dependencies {
-                implementation(kotlin("test-junit"))
-            }
-        }
-
-        val jsMain by getting
-        val jsTest by getting {
-            dependencies {
-                implementation(kotlin("test-js"))
-            }
-        }
-
     }
 }

--- a/core/core.podspec
+++ b/core/core.podspec
@@ -8,8 +8,23 @@ Pod::Spec.new do |spec|
     spec.summary                  = 'Kotlin version of Kxml'
     spec.vendored_frameworks      = 'build/cocoapods/framework/ktxml.framework'
     spec.libraries                = 'c++'
-    spec.ios.deployment_target = '14.1'
+    spec.ios.deployment_target    = '14.1'
                 
+                
+    if !Dir.exist?('build/cocoapods/framework/ktxml.framework') || Dir.empty?('build/cocoapods/framework/ktxml.framework')
+        raise "
+
+        Kotlin framework 'ktxml' doesn't exist yet, so a proper Xcode project can't be generated.
+        'pod install' should be executed after running ':generateDummyFramework' Gradle task:
+
+            ./gradlew :core:generateDummyFramework
+
+        Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
+    end
+                
+    spec.xcconfig = {
+        'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    }
                 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':core',

--- a/core/src/commonTest/kotlin/org/kobjects/ktxml/KtXmlTest.kt
+++ b/core/src/commonTest/kotlin/org/kobjects/ktxml/KtXmlTest.kt
@@ -62,6 +62,7 @@ class KtXmlTest {
         assertEquals(EventType.XML_DECL, parser.nextToken())
         assertEquals(EventType.START_TAG, parser.nextToken())
         assertEquals(EventType.END_TAG, parser.nextToken())
+        assertEquals(EventType.IGNORABLE_WHITESPACE, parser.nextToken())
         assertEquals(EventType.END_DOCUMENT, parser.nextToken())
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This is intended to solve #8, though I went ahead and added _all_ missing targets as this is a pure Kotlin library.

AI-generated, hand-edited, summary:

* Updated Kotlin to the latest version.
* Updated the Gradle wrapper to version 8.12 in `gradle/wrapper/gradle-wrapper.properties` for compatibility with Kotlin.
* Expanded platform support in `core/build.gradle.kts` by adding targets for WASM (both `wasmJs` and `wasmWasi`), macOS, Linux, watchOS, tvOS, Windows, and Android Native platforms.
* Applied the default hierarchy template instead of configuring source sets manually.
* Added a new GitHub Actions workflow to run tests across most Kotlin Multiplatform targets
* Fixed a test in `core/src/commonTest/kotlin/org/kobjects/ktxml/KtXmlTest.kt` by adding a missing assertion for `EventType.IGNORABLE_WHITESPACE`.